### PR TITLE
Bump to 2.3.x to avoid dependencies with systemPath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,11 @@
        <tag>${scmTag}</tag>
    </scm>
    <properties>
-       <revision>2.2.x</revision>
+       <revision>2.3.x</revision>
        <changelist>-SNAPSHOT</changelist>
        <jenkins.version>2.60.3</jenkins.version>
        <java.level>8</java.level>
+       <jaxb-api.version>2.3.0</jaxb-api.version>
    </properties>
 
   <dependencies>
@@ -36,17 +37,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
-      <version>2.2.2</version>
+      <version>${jaxb-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
-      <version>2.2.11</version>
+      <version>${jaxb-api.version}</version>
     </dependency>
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-impl</artifactId>
-      <version>2.2.11</version>
+      <version>${jaxb-api.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
On JAXB 2.2.11, the parent uses `systemPath`.
Which in general is already a bad pattern, but in this case is worse because it tries to load tools.jar from the current JDK.

This dependency got removed in later versions:
https://search.maven.org/artifact/com.sun.xml.bind.mvn/jaxb-parent/2.3.0/pom

I'm choosing 2.3.0, at least for now, to be as close as possible to the previously used 2.2.11, but with `systemPath` usage removed.

@jenkinsci/java11-support 
