### PR TITLE
[JENKINS-56432] - Update the Core dependency to 2.163 to prevent circular dependency on the update site

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== 2.3.0.1 -- 2019-03-06
+
+* link:https://issues.jenkins-ci.org/browse/JENKINS-56432[JENKINS-56432]: Require Jenkins Core 2.163 to prevent circular dependency on the update site
+
 == 2.3.0 -- 2019-01-31
 
 * link:https://github.com/jenkinsci/jaxb-plugin/pull/6[PR-6]: Update `jaxb` libraries to 2.3.0 to avoid using `systemPath`

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
    <properties>
        <revision>2.3.x</revision>
        <changelist>-SNAPSHOT</changelist>
-       <jenkins.version>2.60.3</jenkins.version>
+       <jenkins.version>2.163</jenkins.version>
        <java.level>8</java.level>
        <jaxb-api.version>2.3.0</jaxb-api.version>
    </properties>


### PR DESCRIPTION
See https://issues.jenkins-ci.org/browse/JENKINS-56432 . The approach should be OK. The only risk is that users of older LTS versions may start getting warnings in the update centers once the baseline-specific update center is removed

CC @daniel-beck @jenkinsci/java11-support 
