### PR TITLE
update jaxb-api from 2.3.0 to 2.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
        <changelist>-SNAPSHOT</changelist>
        <jenkins.version>2.163</jenkins.version>
        <java.level>8</java.level>
-       <jaxb-api.version>2.3.0</jaxb-api.version>
+       <jaxb-api.version>2.3.1</jaxb-api.version>
    </properties>
 
   <dependencies>


### PR DESCRIPTION
https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api

https://github.com/javaee/jaxb-v2/releases

https://stackoverflow.com/questions/54632086/java-11-implementation-of-jaxb-api-has-not-been-found-on-module-path-or-classpa

https://github.com/eclipse-ee4j/jaxb-ri/releases <- 2.3.2 ?